### PR TITLE
add iupui

### DIFF
--- a/content/track/us/in/iupui.md
+++ b/content/track/us/in/iupui.md
@@ -1,0 +1,16 @@
+---
+title: "IUPUI"
+date: 2019-01-08T04:32:07.629Z
+tags: []
+latitude: 39.7710802
+longitude: -86.177743
+elevation_meters: 209
+distance_meters: 400
+lap_lanes: 8
+home_lanes: 9
+surface_type: artificial
+surface_color: red
+turn_diameter_meters: 73.2
+turn_radius_b_meters: 34.5
+steeple_water_location: outside
+---


### PR DESCRIPTION
this looks like it should be double radius with the grandstands and soccer field but it isn't measuring so. the dimensions are so tight at the corners of the soccer field they might have made it work.

closes #276 