### PR TITLE
hide empty tags list

### DIFF
--- a/layouts/partials/tag-list.html
+++ b/layouts/partials/tag-list.html
@@ -1,6 +1,6 @@
-{{- if (isset .Params "tags") -}}
+{{- with .Params.tags -}}
   <div class="tags">
-    [{{- range $i, $tag := .Params.tags -}}
+    [{{- range $i, $tag := . -}}
       {{- if $i -}}, {{- end -}}
       <span><a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ $tag }}</a></span>
     {{- end -}}]


### PR DESCRIPTION
primarily for single track pages but would apply anywhere the partial is used