### PR TITLE
put default measurements if none set

### DIFF
--- a/layouts/partials/new-track/to-yaml.js
+++ b/layouts/partials/new-track/to-yaml.js
@@ -1,5 +1,5 @@
 function toYaml (opts={}, cb) {
-  let {title, googleMapUrl, diameter, distance, shoulder, features} = opts
+  let {title, googleMapUrl, diameter = 2, distance, shoulder = 4, features} = opts
 
   googleMapUrl = googleMapUrl.replace(/\s/g, '')
 


### PR DESCRIPTION
this is a convenience when adding new wip tracks on mobile devices. missing measurements in any track will cause a build error in travis